### PR TITLE
Add a direct reference to the remote-viewer executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
   --proxy <proxy>                        SPICE proxy server. This can be used by the client to specify the proxy server. All nodes in a cluster runs
                                          'spiceproxy', so it is up to the client to choose one. By default, we return the node to connect. If specify
                                          http(s)://[host]:[port] then replace proxy option in file .vv. E.g. for reverse proxy.
-  --viewer <viewer> (REQUIRED)           Executable SPICE client remote viewer.
+  --viewer <viewer> (REQUIRED)           Executable SPICE client remote viewer (remote-viewer executable)
   --viewer-options <viewer-options>      Send options directly SPICE Viewer (quote value).
   --start-or-resume                      Run stopped or paused VM
   --wait-for-startup <wait-for-startup>  Wait sec. for startup VM [default: 5]


### PR DESCRIPTION
I would like to add a hint to use `remote-viewer` to avoid a situation like my [previous issue](https://github.com/Corsinvest/cv4pve-pepper/issues/26).
I know that this information is [later in the Readme](https://github.com/Corsinvest/cv4pve-pepper#topical-path-of-remote-viewer), but maybe the next person will miss it like I did 🤦